### PR TITLE
Rework interface with a minimal image-first aesthetic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { useAppStore, type Settings, type FeedItem } from './store'
 import './index.css'
 import './speech-recognition.d.ts'
 
 const orchestrator = new Worker(new URL('./workers/orchestrator.worker.ts', import.meta.url), { type: 'module' })
 const enricher = new Worker(new URL('./workers/enricher.worker.ts', import.meta.url), { type: 'module' })
+
+type AccentStyle = CSSProperties & { '--accent-hue'?: number }
 
 function App() {
   const { feed, settings, setSettings, addFeedItem, updateFeedItem, loadCachedFeed, offline, setOffline } = useAppStore()
@@ -14,18 +17,25 @@ function App() {
   const [currentTranscript, setCurrentTranscript] = useState('')
   const [processingStatus, setProcessingStatus] = useState('')
   const [audioLevel, setAudioLevel] = useState(0)
-  const [transcriptFinal, setTranscriptFinal] = useState('')
-  const [debugInfo, setDebugInfo] = useState<string[]>([])
 
-  const addDebugInfo = (message: string) => {
-    const timestamp = new Date().toLocaleTimeString()
-    setDebugInfo(prev => [...prev.slice(-4), `[${timestamp}] ${message}`])
-  }
+  const totalInsights = useMemo(
+    () => feed.reduce((acc, item) => acc + (item.insights?.length ?? 0), 0),
+    [feed]
+  )
+  const totalTopics = useMemo(
+    () => feed.reduce((acc, item) => acc + (item.topics?.length ?? 0), 0),
+    [feed]
+  )
+  const openQuestions = useMemo(() => {
+    if (feed.length === 0) return 0
+    return feed[feed.length - 1].questions?.length ?? 0
+  }, [feed])
 
   useEffect(() => {
-    loadCachedFeed()
-    addDebugInfo(`🔧 Iniciando sistema - OpenAI API: ${settings.openaiKey ? '✅ Configurada' : '❌ Não configurada'}`)
-    orchestrator.postMessage({ type: 'init', cadence: settings.cadence, language: settings.language, openaiKey: settings.openaiKey })
+    void loadCachedFeed()
+  }, [loadCachedFeed])
+
+  useEffect(() => {
     const handleOnline = () => setOffline(false)
     const handleOffline = () => setOffline(true)
     window.addEventListener('online', handleOnline)
@@ -34,7 +44,7 @@ function App() {
       window.removeEventListener('online', handleOnline)
       window.removeEventListener('offline', handleOffline)
     }
-  }, [])
+  }, [setOffline])
 
   useEffect(() => {
     orchestrator.postMessage({ type: 'init', cadence: settings.cadence, language: settings.language, openaiKey: settings.openaiKey })
@@ -42,82 +52,62 @@ function App() {
 
   useEffect(() => {
     orchestrator.onmessage = (e) => {
-      addDebugInfo('Resposta recebida do orchestrator')
-      setProcessingStatus('🧠 Analisando contexto e extraindo insights...')
+      setProcessingStatus('Sintetizando descobertas')
       const { summary, topics, intents, questions } = e.data
-      addDebugInfo(`Análise concluída: ${topics?.length || 0} tópicos encontrados`)
-
       const id = Date.now()
       addFeedItem({ id, summary, topics, intents, questions, news: [], insights: [], timestamp: Date.now() })
-
-      setProcessingStatus('🔍 Gerando insights e informações...')
       enricher.postMessage({ type: 'enrich', id, topics, openaiKey: settings.openaiKey, offline })
-      addDebugInfo('Solicitação de enriquecimento enviada')
     }
 
     enricher.onmessage = (e) => {
-      addDebugInfo('Enriquecimento recebido')
-      setProcessingStatus('✨ Finalizando insights...')
+      setProcessingStatus('Finalizando insights visuais')
       const { id, news, insights } = e.data
       updateFeedItem(id, { news, insights })
-      addDebugInfo(`Concluído: ${news?.length || 0} informações, ${insights?.length || 0} insights`)
-      setTimeout(() => setProcessingStatus(''), 2000)
+      setTimeout(() => setProcessingStatus(''), 1600)
     }
-  }, [settings.openaiKey, offline])
+  }, [settings.openaiKey, offline, addFeedItem, updateFeedItem])
 
   const start = () => {
     const SpeechRecognitionClass = window.SpeechRecognition || window.webkitSpeechRecognition
     if (!SpeechRecognitionClass) {
-      addDebugInfo('❌ Speech Recognition não suportado neste navegador')
+      setProcessingStatus('Reconhecimento de voz não suportado neste navegador')
       return
     }
 
-    addDebugInfo('🎤 Iniciando reconhecimento de voz...')
     const recognition = new SpeechRecognitionClass()
     recognition.lang = settings.language
     recognition.continuous = true
     recognition.interimResults = true
 
     recognition.onstart = () => {
-      addDebugInfo('✅ Reconhecimento de voz iniciado')
-      setProcessingStatus('🎤 Ouvindo... Pode falar!')
+      setProcessingStatus('Escutando agora')
     }
 
     recognition.onresult = (e) => {
       const transcript = Array.from(e.results).map((r) => r[0].transcript).join(' ')
       setCurrentTranscript(transcript)
-
-      // Simular nível de áudio baseado no comprimento da transcrição
       setAudioLevel(Math.min(transcript.length / 10, 10))
 
       if (e.results[e.results.length - 1].isFinal) {
-        setTranscriptFinal(transcript)
-        addDebugInfo(`📝 Transcrição finalizada: "${transcript.substring(0, 50)}..."`)
-        setProcessingStatus('🔄 Enviando para análise...')
-
+        setProcessingStatus('Processando análise')
         orchestrator.postMessage({ type: 'transcript', text: transcript, offline })
-        addDebugInfo('📤 Transcrição enviada para o orchestrator')
 
-        // Limpar transcrição temporária após envio
         setTimeout(() => {
           setCurrentTranscript('')
           setAudioLevel(0)
-        }, 1000)
-      } else {
-        addDebugInfo('🎧 Capturando áudio...')
+        }, 600)
       }
     }
 
-    recognition.onerror = (e: any) => {
-      addDebugInfo(`❌ Erro no reconhecimento: ${e.error || 'Erro desconhecido'}`)
-      setProcessingStatus('❌ Erro no reconhecimento de voz')
+    recognition.onerror = () => {
+      setProcessingStatus('Erro no reconhecimento de voz')
     }
 
     recognition.onend = () => {
-      addDebugInfo('🔴 Reconhecimento de voz finalizado')
       if (listening) {
-        // Reiniciar automaticamente se ainda estiver no modo listening
-        setTimeout(() => recognition.start(), 100)
+        setTimeout(() => recognition.start(), 120)
+      } else {
+        setProcessingStatus('')
       }
     }
 
@@ -127,12 +117,12 @@ function App() {
   }
 
   const stop = () => {
-    addDebugInfo('🛑 Parando reconhecimento de voz...')
     recognitionRef.current?.stop()
     setListening(false)
     setCurrentTranscript('')
     setAudioLevel(0)
-    setProcessingStatus('')
+    setProcessingStatus('Captura pausada')
+    setTimeout(() => setProcessingStatus(''), 1200)
   }
 
   const exportJson = () => {
@@ -146,239 +136,155 @@ function App() {
     URL.revokeObjectURL(url)
   }
 
+  const statusNarrative = processingStatus || (listening ? 'Captando agora' : 'Pronto para iniciar')
+  const transcriptPreview = currentTranscript
+    ? `“${currentTranscript.slice(0, 140)}${currentTranscript.length > 140 ? '…' : ''}”`
+    : 'Nenhum trecho em captura'
+
   return (
-    <div className="min-h-screen" style={{background: 'linear-gradient(to bottom right, #111827, #1f2937, #111827)'}}>
-      <div className="max-w-6xl mx-auto p-6">
-        {/* Header */}
-        <header className="mb-8 text-center">
-          <h1 className="text-4xl font-bold mb-2 text-gradient">
-            Insider Agent
-          </h1>
-          <p className="text-gray-400">
-            Inteligência em tempo real para suas conversas
-          </p>
-        </header>
-
-        {/* Status Bar */}
-        <div className="mb-6 flex items-center justify-center gap-4 flex-wrap">
-          <div className={`status-indicator ${offline ? 'border-red-500/50' : 'border-green-500/50'}`}>
-            <span className={`w-2 h-2 rounded-full ${offline ? 'bg-red-500' : 'bg-green-500 animate-pulse'}`}></span>
-            <span className="text-xs">{offline ? 'Offline' : 'Online'}</span>
-          </div>
-
-          {listening && (
-            <div className="status-indicator">
-              <div className="sound-wave">
-                <span style={{transform: `scaleY(${0.3 + audioLevel * 0.1})`}}></span>
-                <span style={{transform: `scaleY(${0.3 + audioLevel * 0.15})`}}></span>
-                <span style={{transform: `scaleY(${0.3 + audioLevel * 0.2})`}}></span>
-                <span style={{transform: `scaleY(${0.3 + audioLevel * 0.15})`}}></span>
-                <span style={{transform: `scaleY(${0.3 + audioLevel * 0.1})`}}></span>
-              </div>
-              <span className="text-xs">
-                {currentTranscript ? '🎙️ Capturando...' : '👂 Ouvindo...'}
-              </span>
+    <div className="studio-shell">
+      <div className="studio-backdrop" />
+      <main className="studio-frame">
+        <header className="studio-header">
+          <section className={`hero-card ${listening ? 'hero-card--active' : ''}`}>
+            <div className="hero-media">
+              <div className="hero-image" aria-hidden />
+              <div className="hero-glow" />
             </div>
-          )}
-
-          {processingStatus && (
-            <div className="status-indicator animate-pulse-slow">
-              <span className="text-xs">{processingStatus}</span>
-            </div>
-          )}
-        </div>
-
-        {/* Control Center */}
-        <div className="mb-6 card">
-          <div className="flex flex-col items-center gap-6">
-            {/* Main Control Button */}
-            <div style={{position: 'relative'}}>
-              {!listening ? (
-                <button
-                  onClick={start}
-                  style={{
-                    width: '96px',
-                    height: '96px',
-                    borderRadius: '50%',
-                    background: 'linear-gradient(to right, #059669, #10b981)',
-                    border: 'none',
-                    color: 'white',
-                    boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    transition: 'all 0.2s ease',
-                    transform: 'scale(1)',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = 'linear-gradient(to right, #047857, #059669)'
-                    e.currentTarget.style.transform = 'scale(1.05)'
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = 'linear-gradient(to right, #059669, #10b981)'
-                    e.currentTarget.style.transform = 'scale(1)'
-                  }}
-                >
-                  <svg style={{width: '40px', height: '40px'}} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                  </svg>
-                </button>
-              ) : (
-                <button
-                  onClick={stop}
-                  className="animate-pulse"
-                  style={{
-                    width: '96px',
-                    height: '96px',
-                    borderRadius: '50%',
-                    background: 'linear-gradient(to right, #dc2626, #e11d48)',
-                    border: 'none',
-                    color: 'white',
-                    boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    transition: 'all 0.2s ease',
-                    transform: 'scale(1)',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = 'linear-gradient(to right, #b91c1c, #be185d)'
-                    e.currentTarget.style.transform = 'scale(1.05)'
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = 'linear-gradient(to right, #dc2626, #e11d48)'
-                    e.currentTarget.style.transform = 'scale(1)'
-                  }}
-                >
-                  <svg style={{width: '40px', height: '40px'}} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
-                  </svg>
-                </button>
-              )}
-              <p style={{textAlign: 'center', marginTop: '12px', fontSize: '14px', color: '#9ca3af'}}>
-                {listening ? 'Parar' : 'Iniciar'} Escuta
+            <div className="hero-copy">
+              <span className="hero-eyebrow">Observatório visual de conversas</span>
+              <h1 className="hero-title">Insider Agent</h1>
+              <p className="hero-text">
+                Transforme diálogos em uma biblioteca curada de insights visuais. Capture apenas o essencial e reveja tudo em um
+                ambiente leve, inspirado pelo minimalismo do mymind.
               </p>
             </div>
+          </section>
 
-            {/* Current Transcript Display */}
-            {currentTranscript && (
-              <div className="w-full max-w-2xl p-4 rounded-lg bg-black/20 border border-white/5">
-                <p className="text-sm text-gray-300 italic">"{currentTranscript}"</p>
+          <aside className="hero-side">
+            <div className={`status-chip ${offline ? 'status-chip--offline' : 'status-chip--online'}`}>
+              <span className="status-dot" />
+              <span>{offline ? 'Offline' : 'Sincronizado'}</span>
+            </div>
+            <p className="status-message">{statusNarrative}</p>
+            <div className="metric-tiles">
+              <div className="metric-tile">
+                <span className="metric-number">{feed.length}</span>
+                <span className="metric-label">Sessões</span>
               </div>
-            )}
+              <div className="metric-tile">
+                <span className="metric-number">{totalInsights}</span>
+                <span className="metric-label">Insights</span>
+              </div>
+              <div className="metric-tile">
+                <span className="metric-number">{totalTopics}</span>
+                <span className="metric-label">Tópicos</span>
+                {openQuestions > 0 && <span className="metric-footnote">{openQuestions} perguntas em aberto</span>}
+              </div>
+            </div>
+          </aside>
+        </header>
 
-            {/* Action Buttons */}
-            <div className="flex gap-3">
+        <section className="capture-row">
+          <div className="capture-card">
+            <div className="capture-header">
+              <h2>Captura de áudio</h2>
+              {processingStatus && <span className="capture-status">{processingStatus}</span>}
+            </div>
+            <div className="capture-body">
               <button
-                onClick={() => setShowSettings(!showSettings)}
-                className="btn-secondary flex items-center gap-2"
+                onClick={listening ? stop : start}
+                className={`capture-button ${listening ? 'capture-button--active' : ''}`}
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                Configurações
+                {listening ? 'Parar captura' : 'Iniciar captura'}
               </button>
-
-              <button
-                onClick={exportJson}
-                className="btn-primary flex items-center gap-2"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                </svg>
-                Exportar
+              <div className="audio-visual">
+                <div className="audio-bars">
+                  {Array.from({ length: 6 }).map((_, index) => {
+                    const height = 8 + audioLevel * (index + 1)
+                    return <span key={index} className="audio-bar" style={{ height: `${height}px` }} />
+                  })}
+                </div>
+                <p className="audio-caption">{transcriptPreview}</p>
+              </div>
+            </div>
+            <div className="capture-actions">
+              <button onClick={() => setShowSettings(true)} className="ghost-button" type="button">
+                Preferências
+              </button>
+              <button onClick={exportJson} className="ghost-button ghost-button--primary" type="button">
+                Exportar biblioteca
               </button>
             </div>
           </div>
-        </div>
+        </section>
 
-        {/* Settings Panel */}
-        {showSettings && (
-          <div className="mb-6 card">
+        <section className="feed-section">
+          <div className="section-heading">
+            <div>
+              <h2>Biblioteca de insights</h2>
+              <p>Resumos visuais e referências essenciais das suas sessões.</p>
+            </div>
+            <span className="section-count">{feed.length} sessões</span>
+          </div>
+          <Feed feed={feed} />
+        </section>
+      </main>
+
+      {showSettings && (
+        <div className="settings-layer" role="dialog" aria-modal="true">
+          <div className="settings-sheet">
+            <button className="settings-close" type="button" onClick={() => setShowSettings(false)} aria-label="Fechar">
+              ×
+            </button>
             <Settings settings={settings} setSettings={setSettings} />
           </div>
-        )}
-
-        {/* Debug Panel */}
-        {debugInfo.length > 0 && (
-          <div className="mb-6 card">
-            <h3 className="text-lg font-semibold mb-3">🔍 Status do Sistema</h3>
-            <div className="space-y-1">
-              {debugInfo.map((info, i) => (
-                <p key={i} className="text-xs font-mono" style={{color: '#94a3b8'}}>
-                  {info}
-                </p>
-              ))}
-            </div>
-            {transcriptFinal && (
-              <div className="mt-4 p-3 rounded-lg" style={{backgroundColor: 'rgba(34, 197, 94, 0.1)', border: '1px solid rgba(34, 197, 94, 0.2)'}}>
-                <p className="text-sm font-semibold text-green-400 mb-1">📝 Última Transcrição Processada:</p>
-                <p className="text-sm" style={{color: '#d1d5db'}}>"{transcriptFinal}"</p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Feed Display */}
-        <div className="card">
-          <h2 className="text-xl font-bold mb-4 text-gradient">Feed de Inteligência</h2>
-          <Feed feed={feed} />
         </div>
-      </div>
+      )}
     </div>
   )
 }
 
 function Settings({ settings, setSettings }: { settings: Settings; setSettings: (s: Partial<Settings>) => void }) {
   return (
-    <div className="space-y-4">
-      <h3 className="text-lg font-semibold mb-4">Configurações</h3>
+    <div className="settings-content">
+      <h2 className="settings-heading">Preferências</h2>
+      <p className="settings-description">Ajuste a frequência de coleta e idioma utilizados pelo agente.</p>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">
-            Cadência de Análise
-          </label>
+      <div className="settings-grid">
+        <label className="settings-field">
+          <span className="settings-label">Cadência de análise</span>
           <select
             value={settings.cadence}
             onChange={(e) => setSettings({ cadence: Number(e.target.value) })}
-            className="w-full px-3 py-2 rounded-lg bg-black/20 border border-white/10 text-white text-sm focus:border-purple-500 focus:outline-none"
+            className="settings-input"
           >
             <option value={10}>10 segundos</option>
             <option value={30}>30 segundos</option>
             <option value={60}>1 minuto</option>
           </select>
-        </div>
+        </label>
 
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">
-            Idioma
-          </label>
+        <label className="settings-field">
+          <span className="settings-label">Idioma</span>
           <input
             value={settings.language}
             onChange={(e) => setSettings({ language: e.target.value })}
-            className="w-full px-3 py-2 rounded-lg bg-black/20 border border-white/10 text-white text-sm focus:border-purple-500 focus:outline-none"
+            className="settings-input"
             placeholder="pt-BR"
           />
-        </div>
+        </label>
 
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">
-            OpenAI API Key
-          </label>
+        <label className="settings-field">
+          <span className="settings-label">OpenAI API Key</span>
           <input
             type="password"
             value={settings.openaiKey}
             onChange={(e) => setSettings({ openaiKey: e.target.value })}
-            className="w-full px-3 py-2 rounded-lg bg-black/20 border border-white/10 text-white text-sm focus:border-purple-500 focus:outline-none"
+            className="settings-input"
             placeholder="sk-..."
           />
-        </div>
-
+        </label>
       </div>
     </div>
   )
@@ -387,129 +293,93 @@ function Settings({ settings, setSettings }: { settings: Settings; setSettings: 
 function Feed({ feed }: { feed: FeedItem[] }) {
   if (feed.length === 0) {
     return (
-      <div className="text-center py-8">
-        <svg className="w-16 h-16 mx-auto text-gray-600 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-        </svg>
-        <p className="text-gray-500 text-sm">Nenhuma análise ainda. Clique em "Iniciar Escuta" para começar.</p>
+      <div className="empty-board">
+        <div className="empty-illustration" aria-hidden>
+          <div className="empty-gradient" />
+        </div>
+        <div className="empty-copy">
+          <h3>Nenhum insight ainda</h3>
+          <p>Inicie uma captura para construir sua galeria pessoal de referências.</p>
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="space-y-4">
-      {feed.slice().reverse().map((item) => (
-        <div
-          key={item.id}
-          className="p-4 rounded-lg bg-black/20 border border-white/5 hover:border-white/10 transition-colors"
-        >
-          <div className="mb-4">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-xs text-gray-400">
-                📅 {new Date(item.timestamp).toLocaleString('pt-BR')}
-              </p>
-            </div>
-            <div className="p-3 rounded-lg bg-gradient-to-r from-purple-900/20 to-indigo-900/20 border-l-4 border-purple-500">
-              <p className="text-sm text-gray-100 leading-relaxed">
-                {typeof item.summary === 'string' && !item.summary.includes('{')
-                  ? item.summary
-                  : 'Análise em processamento...'}
-              </p>
-            </div>
-          </div>
+    <div className="story-grid">
+      {feed
+        .slice()
+        .reverse()
+        .map((item) => {
+          const questionCount = item.questions?.length ?? 0
+          const accentStyle: AccentStyle = { '--accent-hue': item.id % 360 }
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-xs">
-            {/* Topics */}
-            <div>
-              <h4 className="font-semibold text-purple-400 mb-2 flex items-center gap-1">
-                <span>🏷️</span> Tópicos
-              </h4>
-              <div className="flex flex-wrap gap-1">
-                {item.topics && item.topics.length > 0 ? (
-                  item.topics.map((topic, i) => (
-                    <span
-                      key={i}
-                      className="px-2 py-1 rounded-full bg-purple-500/10 text-purple-300 border border-purple-500/20 text-xs"
-                    >
-                      {typeof topic === 'string' ? topic : 'Processando...'}
-                    </span>
-                  ))
-                ) : (
-                  <span className="text-gray-500 italic">Identificando tópicos...</span>
-                )}
-              </div>
-            </div>
+          return (
+            <article key={item.id} className="story-card" style={accentStyle}>
+              <div className="story-image" aria-hidden />
+              <div className="story-content">
+                <header className="story-header">
+                  <time className="story-time">{new Date(item.timestamp).toLocaleString('pt-BR')}</time>
+                  {questionCount > 0 && <span className="story-badge">{questionCount} perguntas</span>}
+                </header>
 
-            {/* News */}
-            <div>
-              <h4 className="font-semibold text-blue-400 mb-2 flex items-center gap-1">
-                <span>📰</span> Informações
-              </h4>
-              <div className="space-y-2">
-                {item.news && item.news.length > 0 ? (
-                  item.news.slice(0, 3).map((n, i) => (
-                    <a
-                      key={i}
-                      href={n.url !== '#' ? n.url : undefined}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="block p-2 rounded bg-blue-500/10 hover:bg-blue-500/20 transition-colors"
-                    >
-                      <p className="text-blue-300 text-xs leading-relaxed">
-                        {n.title}
-                      </p>
-                    </a>
-                  ))
-                ) : (
-                  <div className="p-2 rounded bg-gray-800/50">
-                    <p className="text-gray-400 text-xs italic">Gerando informações relevantes...</p>
-                  </div>
-                )}
-              </div>
-            </div>
+                <p className="story-summary">
+                  {typeof item.summary === 'string' && !item.summary.includes('{')
+                    ? item.summary
+                    : 'Análise em processamento...'}
+                </p>
 
-            {/* Insights */}
-            <div>
-              <h4 className="font-semibold text-green-400 mb-2 flex items-center gap-1">
-                <span>💡</span> Insights
-              </h4>
-              <div className="space-y-2">
-                {item.insights && item.insights.length > 0 ? (
-                  item.insights.map((insight, i) => (
-                    <div key={i} className="p-2 rounded bg-green-500/10 border-l-2 border-green-500">
-                      <p className="text-gray-200 text-xs leading-relaxed">
-                        {insight}
-                      </p>
+                <div className="story-details">
+                  <div className="story-group">
+                    <span className="story-label">Tópicos</span>
+                    <div className="story-chips">
+                      {item.topics && item.topics.length > 0 ? (
+                        item.topics.map((topic, i) => (
+                          <span key={i} className="story-chip">
+                            {typeof topic === 'string' ? topic : 'Processando...'}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="story-chip story-chip--ghost">Identificando tópicos</span>
+                      )}
                     </div>
-                  ))
-                ) : (
-                  <div className="p-2 rounded bg-gray-800/50">
-                    <p className="text-gray-400 text-xs italic">Analisando contexto...</p>
                   </div>
-                )}
-              </div>
-            </div>
-          </div>
 
-          {/* Questions */}
-          {item.questions && item.questions.length > 0 && (
-            <div className="mt-4 pt-4 border-t border-white/5">
-              <h4 className="text-xs font-semibold text-yellow-400 mb-2 flex items-center gap-1">
-                <span>❓</span> Questões Levantadas
-              </h4>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                {item.questions.map((q, i) => (
-                  <div key={i} className="p-2 rounded bg-yellow-500/10 border-l-2 border-yellow-500">
-                    <p className="text-xs text-gray-300">
-                      {typeof q === 'string' ? q : 'Processando...'}
-                    </p>
+                  <div className="story-group">
+                    <span className="story-label">Insights</span>
+                    <ul className="story-list">
+                      {item.insights && item.insights.length > 0 ? (
+                        item.insights.map((insight, i) => <li key={i}>{insight}</li>)
+                      ) : (
+                        <li className="story-empty">Aguardando insights</li>
+                      )}
+                    </ul>
                   </div>
-                ))}
+
+                  <div className="story-group">
+                    <span className="story-label">Referências</span>
+                    <div className="story-links">
+                      {item.news && item.news.length > 0 ? (
+                        item.news.slice(0, 2).map((n, i) => (
+                          <a
+                            key={i}
+                            href={n.url !== '#' ? n.url : undefined}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {n.title}
+                          </a>
+                        ))
+                      ) : (
+                        <span className="story-empty">Sem fontes externas ainda</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-      ))}
+            </article>
+          )
+        })}
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,140 +1,740 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+:root {
+  color-scheme: light;
+  --bg: #f5f5f3;
+  --surface: #ffffff;
+  --surface-subtle: rgba(255, 255, 255, 0.72);
+  --ink: #111827;
+  --muted: #6b7280;
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --border: rgba(17, 24, 39, 0.08);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 25px 55px rgba(15, 23, 42, 0.16);
+  --shadow-card: 0 18px 40px rgba(15, 23, 42, 0.12);
+  --font-sans: 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
 
+* {
+  box-sizing: border-box;
+}
+
+html,
 body {
-  background: #0f172a;
-  color: white;
+  margin: 0;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.1), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.12), transparent 60%);
+  pointer-events: none;
+  z-index: -2;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font-family: inherit;
+}
+
+#root {
   min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
 }
 
-.glass-morphism {
-  backdrop-filter: blur(16px);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-}
-
-.btn-primary {
-  padding: 12px 24px;
-  border-radius: 8px;
-  background: linear-gradient(to right, #7c3aed, #4338ca);
-  font-weight: 500;
-  transform: scale(1);
-  transition: all 0.2s;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-}
-
-.btn-primary:hover {
-  background: linear-gradient(to right, #6d28d9, #3730a3);
-  transform: scale(1.05);
-}
-
-.btn-secondary {
-  padding: 12px 24px;
-  border-radius: 8px;
-  background: #374151;
-  border: 1px solid #4b5563;
-  font-weight: 500;
-  transform: scale(1);
-  transition: all 0.2s;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-}
-
-.btn-secondary:hover {
-  background: #4b5563;
-  transform: scale(1.05);
-}
-
-.text-gradient {
-  background: linear-gradient(to right, #c084fc, #818cf8);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.card {
-  backdrop-filter: blur(16px);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-  border-radius: 12px;
-  padding: 24px;
-  transition: box-shadow 0.3s;
+.studio-shell {
   position: relative;
-  z-index: 1;
+  min-height: 100vh;
+  padding: 40px 0 80px;
 }
 
-.card:hover {
-  box-shadow: 0 35px 60px -12px rgba(0, 0, 0, 0.4);
+.studio-backdrop {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.85) 0%, rgba(245, 245, 243, 0.92) 100%);
+  z-index: -1;
 }
 
-.status-indicator {
+.studio-frame {
+  width: min(1180px, 90vw);
+  margin: 0 auto;
   display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.studio-header {
+  display: grid;
+  gap: 40px;
+  grid-template-columns: 1.6fr 1fr;
+  align-items: stretch;
+}
+
+.hero-card {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  background: var(--surface-subtle);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--shadow-soft);
+  min-height: 320px;
+}
+
+.hero-card--active .hero-image {
+  transform: scale(1.04);
+}
+
+.hero-media {
+  position: relative;
+  flex: 1;
+  min-height: 320px;
+}
+
+.hero-image {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-image: linear-gradient(130deg, rgba(79, 70, 229, 0.88), rgba(14, 165, 233, 0.6)),
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), transparent 55%),
+    radial-gradient(circle at 70% 70%, rgba(236, 72, 153, 0.32), transparent 60%);
+  background-size: cover;
+  filter: saturate(1.15);
+  transform: scale(1.02);
+  transition: transform 1200ms cubic-bezier(0.23, 1, 0.32, 1);
+  animation: heroFloat 18s ease-in-out infinite alternate;
+}
+
+.hero-glow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.28), transparent 60%);
+  mix-blend-mode: screen;
+  opacity: 0.9;
+}
+
+.hero-copy {
+  flex: 1;
+  padding: 48px 48px 48px 52px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 18px;
+}
+
+.hero-eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(17, 24, 39, 0.52);
+}
+
+.hero-title {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.hero-text {
+  margin: 0;
+  max-width: 32ch;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--muted);
+}
+
+.hero-side {
+  padding: 36px;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  backdrop-filter: blur(14px);
+}
+
+.status-chip {
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  border-radius: 9999px;
-  backdrop-filter: blur(16px);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  font-size: 14px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 500;
 }
 
-.sound-wave {
+.status-chip--online {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.status-chip--offline {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 4px currentColor, 0 0 18px currentColor;
+  opacity: 0.32;
+}
+
+.status-message {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.metric-tiles {
+  display: grid;
+  gap: 18px;
+}
+
+.metric-tile {
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(17, 24, 39, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-number {
+  font-size: 2.2rem;
+  font-weight: 600;
+}
+
+.metric-label {
+  font-size: 0.95rem;
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.metric-footnote {
+  font-size: 0.8rem;
+  color: rgba(17, 24, 39, 0.45);
+}
+
+.capture-row {
+  display: flex;
+  justify-content: center;
+}
+
+.capture-card {
+  width: 100%;
+  padding: 32px 36px;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.capture-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.capture-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.capture-status {
+  font-size: 0.9rem;
+  color: var(--accent-strong);
+  background: rgba(99, 102, 241, 0.12);
+  padding: 6px 14px;
+  border-radius: 999px;
+}
+
+.capture-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.capture-button {
+  align-self: flex-start;
+  padding: 14px 26px;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: white;
+  box-shadow: 0 16px 30px rgba(79, 70, 229, 0.28);
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1), box-shadow 320ms ease;
+}
+
+.capture-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 36px rgba(79, 70, 229, 0.32);
+}
+
+.capture-button--active {
+  background: linear-gradient(120deg, rgba(17, 24, 39, 0.92), rgba(17, 24, 39, 0.8));
+  box-shadow: 0 20px 36px rgba(17, 24, 39, 0.22);
+}
+
+.audio-visual {
   display: flex;
   align-items: center;
-  gap: 4px;
-  height: 24px;
+  gap: 24px;
 }
 
-.sound-wave span {
-  width: 4px;
-  height: 100%;
-  background: linear-gradient(to top, #10b981, #34d399);
-  border-radius: 2px;
-  animation: soundWave 1s ease-in-out infinite;
+.audio-bars {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 60px;
 }
 
-.sound-wave span:nth-child(2) {
-  animation-delay: 0.1s;
+.audio-bar {
+  width: 6px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.8), rgba(79, 70, 229, 0.45));
+  transition: height 280ms ease, transform 280ms ease;
 }
 
-.sound-wave span:nth-child(3) {
-  animation-delay: 0.2s;
+.capture-button--active + .audio-visual .audio-bar {
+  animation: wavePulse 1600ms ease-in-out infinite;
 }
 
-.sound-wave span:nth-child(4) {
-  animation-delay: 0.3s;
+.audio-caption {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(17, 24, 39, 0.58);
+  line-height: 1.6;
+  max-width: 50ch;
 }
 
-.sound-wave span:nth-child(5) {
-  animation-delay: 0.4s;
+.capture-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
 }
 
-@keyframes soundWave {
-  0%, 100% {
-    transform: scaleY(0.3);
+.ghost-button {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--ink);
+  cursor: pointer;
+  transition: border 200ms ease, transform 200ms ease, box-shadow 200ms ease;
+}
+
+.ghost-button:hover {
+  border-color: rgba(17, 24, 39, 0.26);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.08);
+}
+
+.ghost-button--primary {
+  border-color: rgba(99, 102, 241, 0.28);
+  color: var(--accent-strong);
+}
+
+.feed-section {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.section-heading h2 {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.section-count {
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.05);
+  font-size: 0.9rem;
+}
+
+.story-grid {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.story-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--shadow-card);
+  transition: transform 360ms cubic-bezier(0.22, 1, 0.36, 1), box-shadow 360ms ease;
+}
+
+.story-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 48px rgba(15, 23, 42, 0.16);
+}
+
+.story-image {
+  height: 180px;
+  background: linear-gradient(135deg, hsl(var(--accent-hue, 220) 85% 68%), hsl(calc(var(--accent-hue, 220) + 30) 80% 60%));
+  position: relative;
+}
+
+.story-image::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  opacity: 0.6;
+}
+
+.story-content {
+  padding: 24px 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.story-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.story-time {
+  font-size: 0.85rem;
+  color: rgba(17, 24, 39, 0.55);
+}
+
+.story-badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(236, 72, 153, 0.12);
+  color: #be185d;
+  font-size: 0.85rem;
+}
+
+.story-summary {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--ink);
+}
+
+.story-details {
+  display: grid;
+  gap: 16px;
+}
+
+.story-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.story-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(17, 24, 39, 0.4);
+}
+
+.story-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.story-chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.05);
+  font-size: 0.9rem;
+}
+
+.story-chip--ghost {
+  color: rgba(17, 24, 39, 0.5);
+}
+
+.story-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  color: rgba(17, 24, 39, 0.8);
+}
+
+.story-list li {
+  line-height: 1.5;
+}
+
+.story-empty {
+  color: rgba(17, 24, 39, 0.5);
+  font-size: 0.9rem;
+}
+
+.story-links {
+  display: grid;
+  gap: 8px;
+}
+
+.story-links a {
+  text-decoration: none;
+  color: var(--accent-strong);
+  font-weight: 500;
+  transition: opacity 200ms ease;
+}
+
+.story-links a:hover {
+  opacity: 0.76;
+}
+
+.empty-board {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  align-items: center;
+  padding: 28px 32px;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: var(--shadow-card);
+  gap: 24px;
+}
+
+.empty-illustration {
+  position: relative;
+  height: 160px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(14, 165, 233, 0.35));
+}
+
+.empty-gradient {
+  position: absolute;
+  inset: 12px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  opacity: 0.6;
+}
+
+.empty-copy h3 {
+  margin: 0 0 8px;
+}
+
+.empty-copy p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.settings-layer {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.32);
+  backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  z-index: 20;
+}
+
+.settings-sheet {
+  position: relative;
+  width: min(420px, 90vw);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--shadow-soft);
+  padding: 36px;
+  display: flex;
+}
+
+.settings-close {
+  position: absolute;
+  top: 20px;
+  right: 24px;
+  background: none;
+  border: none;
+  font-size: 1.6rem;
+  cursor: pointer;
+  color: rgba(17, 24, 39, 0.4);
+}
+
+.settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.settings-heading {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.settings-description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.settings-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 0.95rem;
+}
+
+.settings-label {
+  color: rgba(17, 24, 39, 0.6);
+  font-weight: 500;
+}
+
+.settings-input {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  padding: 12px 14px;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  transition: border 200ms ease, box-shadow 200ms ease;
+}
+
+.settings-input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.16);
+}
+
+button:focus-visible,
+.settings-input:focus-visible,
+select:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.32);
+}
+
+select.settings-input {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(17, 24, 39, 0.4) 50%),
+    linear-gradient(135deg, rgba(17, 24, 39, 0.4) 50%, transparent 50%);
+  background-position: calc(100% - 14px) calc(1rem + 4px), calc(100% - 8px) calc(1rem + 4px);
+  background-size: 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 32px;
+}
+
+@keyframes heroFloat {
+  0% {
+    transform: scale(1.02) translateY(0);
   }
-  50% {
+  100% {
+    transform: scale(1.07) translateY(-6px);
+  }
+}
+
+@keyframes wavePulse {
+  0%,
+  100% {
     transform: scaleY(1);
   }
-}
-
-@keyframes pulse {
-  0%, 100% {
-    opacity: 1;
-  }
   50% {
-    opacity: 0.5;
+    transform: scaleY(1.3);
   }
 }
 
-.animate-pulse-slow {
-  animation: pulse 3s ease-in-out infinite;
+@media (max-width: 1024px) {
+  .studio-header {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    flex-direction: column;
+  }
+
+  .hero-copy {
+    padding: 36px;
+  }
+
+  .hero-media {
+    min-height: 240px;
+  }
 }
 
-.animate-pulse {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+@media (max-width: 768px) {
+  .studio-shell {
+    padding: 24px 0 60px;
+  }
+
+  .studio-frame {
+    width: calc(100vw - 40px);
+    gap: 40px;
+  }
+
+  .capture-card {
+    padding: 28px;
+  }
+
+  .audio-visual {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .empty-board {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .empty-illustration {
+    width: 100%;
+  }
+
+  .settings-sheet {
+    padding: 28px 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the previous maximalist shell with a lightweight, image-led hero layout and refined status metrics
- streamline audio capture controls, removing front-end logs while keeping fluid visual feedback and focused settings overlay
- redesign the intelligence feed into gradient gallery cards with concise placeholders and an empty state aligned to the new language

## Testing
- npm run build
- npm run lint *(fails: pre-existing lint errors for `any` usage in speech-recognition and worker files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a55cf5d48332917b556623440be6