### PR TITLE
Fix orchestrator fallback typing

### DIFF
--- a/src/workers/orchestrator.worker.ts
+++ b/src/workers/orchestrator.worker.ts
@@ -103,13 +103,12 @@ async function processBuffer() {
         console.error('[Orchestrator] JSON Parse Error:', parseError)
         // Fallback: extract what we can from the response
         const content = data.choices?.[0]?.message?.content || ''
-        const fallback = Array.from(
-          new Set(
-            content
-              .split(/[^\p{L}\p{N}]+/u)
-              .filter((word: string) => word.length > 4)
-          )
+        const fallbackSet = new Set<string>(
+          content
+            .split(/[^\p{L}\p{N}]+/u)
+            .filter((word: string) => word.length > 4)
         )
+        const fallback = Array.from(fallbackSet)
         result.topics = fallback.length > 0 ? fallback.slice(0, 5) : extractKeywordsLocal(text)
       }
     } catch (fetchError) {


### PR DESCRIPTION
## Summary
- ensure orchestrator worker builds when falling back to parsed topics
- type the fallback keyword set explicitly so TypeScript infers string arrays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb40cf0ab48332b69733c1e98396cc